### PR TITLE
squid:S2131 - Primitives should not be boxed just for String conversion

### DIFF
--- a/app/src/main/java/com/sigmobile/dawebmail/ViewEmail.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/ViewEmail.java
@@ -178,7 +178,7 @@ public class ViewEmail extends AppCompatActivity implements ViewMailListener {
     }
 
     private void markWebmailAsRead() {
-        new MailAction(getApplicationContext(), currentUser, getString(R.string.msg_action_read), "" + currentEmail.getContentID(), new MailActionListener() {
+        new MailAction(getApplicationContext(), currentUser, getString(R.string.msg_action_read), String.valueOf(currentEmail.getContentID()), new MailActionListener() {
             @Override
             public void onPreMailAction() {
 

--- a/app/src/main/java/com/sigmobile/dawebmail/asyncTasks/Login.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/asyncTasks/Login.java
@@ -41,6 +41,6 @@ public class Login extends AsyncTask<Void, Void, Void> {
     protected void onPostExecute(Void aVoid) {
         super.onPostExecute(aVoid);
         finalTime = System.currentTimeMillis();
-        loginListener.onPostLogin(loggedIn, "" + (finalTime - initTime), user);
+        loginListener.onPostLogin(loggedIn, String.valueOf(finalTime - initTime), user);
     }
 }

--- a/app/src/main/java/com/sigmobile/dawebmail/asyncTasks/RefreshInbox.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/asyncTasks/RefreshInbox.java
@@ -60,7 +60,7 @@ public class RefreshInbox extends AsyncTask<Void, Void, Void> {
         super.onPostExecute(aVoid);
 
         if (result)
-            settings.save(Settings.KEY_LAST_REFRESHED, "" + System.currentTimeMillis());
+            settings.save(Settings.KEY_LAST_REFRESHED, String.valueOf(System.currentTimeMillis()));
 
         listener.onPostRefresh(result, refreshedEmails, user);
     }

--- a/app/src/main/java/com/sigmobile/dawebmail/fragments/SmartBoxFragment.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/fragments/SmartBoxFragment.java
@@ -96,12 +96,12 @@ public class SmartBoxFragment extends Fragment {
                 senderCount.put(emails.get(i).getFromName(), 1);
         }
 
-        smart_total_emails.setText("" + emails.size());
+        smart_total_emails.setText(String.valueOf(emails.size()));
         double avgLength = Math.round((totalLength / (double) (emails.size())) * 100) / 100.0;
-        smart_total_avg_length.setText("" + avgLength + " words");
-        smart_total_longest_length.setText("" + longestLength + " words\n" + longestSubject);
-        smart_total_per_att.setText("" + (100 * emailsWithAttachment) / emails.size() + " %");
-        smart_total_no_of_opened.setText("" + ((100 * readEmails) / emails.size()) + " %");
+        smart_total_avg_length.setText(String.valueOf(avgLength) + " words");
+        smart_total_longest_length.setText(String.valueOf(longestLength) + " words\n" + longestSubject);
+        smart_total_per_att.setText(String.valueOf((100 * emailsWithAttachment) / emails.size()) + " %");
+        smart_total_no_of_opened.setText(String.valueOf((100 * readEmails) / emails.size()) + " %");
 
         String date = getDateFromMillis(settings.getString(Settings.KEY_LAST_REFRESHED));
         smart_total_last_refresh.setText("Last refreshed - " + date);

--- a/app/src/main/java/com/sigmobile/dawebmail/utils/BasePath.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/utils/BasePath.java
@@ -28,7 +28,7 @@ public class BasePath {
         ArrayList<String> attachments = new ArrayList<>();
         if (new File(getBasePath(context)).listFiles() != null)
             for (File file : new File(getBasePath(context)).listFiles()) {
-                if (file.getName().split("-")[0].toString().equals("" + contentID)) {
+                if (file.getName().split("-")[0].toString().equals(String.valueOf(contentID))) {
                     attachments.add(file.getAbsolutePath());
                 }
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - Primitives should not be boxed just for "String" conversion

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131

Please let me know if you have any questions.

M-Ezzat
