### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/com/sigmobile/dawebmail/database/CurrentUser.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/database/CurrentUser.java
@@ -7,7 +7,7 @@ import android.preference.PreferenceManager;
 /**
  * Created by rish on 6/10/15.
  */
-public class CurrentUser {
+public final class CurrentUser {
 
     /**
      * Only a single user can be active at once.
@@ -15,6 +15,10 @@ public class CurrentUser {
      */
 
     private static String CURRENT_USERNAME = "CURRENT_USER";
+
+    private CurrentUser() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void setCurrentUser(User currentUser, Context context) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);

--- a/app/src/main/java/com/sigmobile/dawebmail/services/BackgroundRunner.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/services/BackgroundRunner.java
@@ -13,9 +13,13 @@ import java.util.Calendar;
 /**
  * Created by rish on 6/10/15.
  */
-public class BackgroundRunner {
+public final class BackgroundRunner {
 
     private final static String TAG = "BackgroundRunner";
+
+    private BackgroundRunner() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void startService(Context context) {
         Intent intent = new Intent(context, BackgroundService.class);

--- a/app/src/main/java/com/sigmobile/dawebmail/services/NotificationMaker.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/services/NotificationMaker.java
@@ -22,7 +22,11 @@ import java.util.ArrayList;
 /**
  * Created by rish on 6/10/15.
  */
-public class NotificationMaker {
+public final class NotificationMaker {
+
+    private NotificationMaker() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void showNotification(Context context, User user, String fromName, String subject) {
         Settings settings = new Settings(context);

--- a/app/src/main/java/com/sigmobile/dawebmail/utils/BasePath.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/utils/BasePath.java
@@ -11,7 +11,11 @@ import java.util.ArrayList;
 /**
  * Created by rish on 8/1/16.
  */
-public class BasePath {
+public final class BasePath {
+
+    private BasePath() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
 
     public static String getBasePath(Context context) {
         File sdCard = Environment.getExternalStorageDirectory();

--- a/app/src/main/java/com/sigmobile/dawebmail/utils/ConnectionManager.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/utils/ConnectionManager.java
@@ -7,7 +7,11 @@ import android.telephony.TelephonyManager;
 /**
  * Created by rish on 16/7/15.
  */
-public class ConnectionManager {
+public final class ConnectionManager {
+
+    private ConnectionManager() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
 
     public static Boolean isConnectedByWifi(Context context) {
         try {

--- a/app/src/main/java/com/sigmobile/dawebmail/utils/Constants.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/utils/Constants.java
@@ -3,7 +3,7 @@ package com.sigmobile.dawebmail.utils;
 /**
  * Created by rish on 6/10/15.
  */
-public class Constants {
+public final class Constants {
 
     public static String FOLDER = "FOLDER";
     public static String INBOX = "INBOX";
@@ -26,5 +26,9 @@ public class Constants {
 
     public static String REFRESH_TYPE_LOAD_MORE = "REFRESH_TYPE_LOAD_MORE";
     public static String REFRESH_TYPE_REFRESH = "REFRESH_TYPE_REFRESH";
+
+    private Constants() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
 
 }

--- a/app/src/main/java/com/sigmobile/dawebmail/utils/DateUtils.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/utils/DateUtils.java
@@ -10,7 +10,12 @@ import java.util.Calendar;
 /**
  * Created by rish on 8/1/16.
  */
-public class DateUtils {
+public final class DateUtils {
+
+    private DateUtils() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
+
     public static String getDate(Context context, long milliSeconds) {
 
         int ONE_HOUR = 1000 * 60 * 60;

--- a/app/src/main/java/com/sigmobile/dawebmail/utils/FileUtils.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/utils/FileUtils.java
@@ -10,7 +10,11 @@ import java.io.File;
 /**
  * Created by rish on 11/1/16.
  */
-public class FileUtils {
+public final class FileUtils {
+
+    private FileUtils() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
 
     public static void openDoc(Context context, String filePath) {
         File file = new File(filePath);

--- a/app/src/main/java/com/sigmobile/dawebmail/utils/TheFont.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/utils/TheFont.java
@@ -6,9 +6,13 @@ import android.graphics.Typeface;
 /**
  * Created by rish on 6/10/15.
  */
-public class TheFont {
+public final class TheFont {
 
     private static Typeface typeface;
+
+    private TheFont() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
 
     public static Typeface getFont(Context context) {
         if (typeface == null)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
