### PR TITLE
Cleanup - squid:S1155 - Collection.isEmpty() should be used to test f…

### DIFF
--- a/app/src/main/java/com/sigmobile/dawebmail/LoginActivity.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/LoginActivity.java
@@ -137,7 +137,7 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
     @Override
     public void onBackPressed() {
         if (CurrentUser.getCurrentUser(this) == null) {
-            if (User.getAllUsers().size() > 0)
+            if (!User.getAllUsers().isEmpty())
                 CurrentUser.setCurrentUser(User.getAllUsers().get(0), getApplicationContext());
         } else {
             finish();

--- a/app/src/main/java/com/sigmobile/dawebmail/MainActivity.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/MainActivity.java
@@ -285,7 +285,7 @@ public class MainActivity extends AppCompatActivity {
                  * Delete the current User and set the next user in line as current user
                  */
                 User.deleteUser(currentUser);
-                if (User.getAllUsers().size() != 0)
+                if (!User.getAllUsers().isEmpty())
                     CurrentUser.setCurrentUser(User.getAllUsers().get(0), getApplicationContext());
                 else
                     CurrentUser.setCurrentUser(null, getApplicationContext());

--- a/app/src/main/java/com/sigmobile/dawebmail/database/EmailMessage.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/database/EmailMessage.java
@@ -132,14 +132,14 @@ public class EmailMessage extends SugarRecord<EmailMessage> implements Serializa
 
     public static EmailMessage getLatestWebmailOfUser(User user) {
         List<EmailMessage> emailMessages = getAllMailsOfUser(user);
-        if (emailMessages.size() > 0)
+        if (!emailMessages.isEmpty())
             return emailMessages.get(emailMessages.size() - 1);
         return null;
     }
 
     public static EmailMessage getLastWebmailOfUser(User user) {
         List<EmailMessage> emailMessages = getAllMailsOfUser(user);
-        if (emailMessages.size() > 0)
+        if (!emailMessages.isEmpty())
             return emailMessages.get(0);
         return null;
     }

--- a/app/src/main/java/com/sigmobile/dawebmail/fragments/FolderFragment.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/fragments/FolderFragment.java
@@ -202,7 +202,7 @@ public class FolderFragment extends Fragment implements RefreshInboxListener, Mu
                     Snackbar.make(swipeRefreshLayout, refreshedEmailsSize + getString(R.string.snackbar_new_webmail_many), Snackbar.LENGTH_LONG).show();
                 progressDialog2.dismiss();
 
-                if (allEmails.size() != 0) {
+                if (!allEmails.isEmpty()) {
                     emptyLayout.setVisibility(View.GONE);
                     swipeRefreshLayout.setVisibility(View.VISIBLE);
                 } else {
@@ -258,7 +258,7 @@ public class FolderFragment extends Fragment implements RefreshInboxListener, Mu
             }
         });
 
-        if (emailsMarkedForAction.size() > 0) {
+        if (!emailsMarkedForAction.isEmpty()) {
             if (fabDelete.getVisibility() != View.VISIBLE) {
                 fabDelete.setVisibility(View.VISIBLE);
                 fabDelete.startAnimation(AnimationUtils.loadAnimation(getActivity(), R.anim.abc_slide_in_bottom));

--- a/app/src/main/java/com/sigmobile/dawebmail/fragments/InboxFragment.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/fragments/InboxFragment.java
@@ -139,7 +139,7 @@ public class InboxFragment extends Fragment implements RefreshInboxListener, Mul
         recyclerView.setItemAnimator(new DefaultItemAnimator());
         recyclerView.setAdapter(mailAdapter);
 
-        if (allEmails.size() == 0) {
+        if (allEmails.isEmpty()) {
             new RefreshInbox(currentUser, getActivity(), InboxFragment.this, Constants.INBOX, Constants.REFRESH_TYPE_LOAD_MORE).execute();
             allEmails = new ArrayList<>();
         }
@@ -383,7 +383,7 @@ public class InboxFragment extends Fragment implements RefreshInboxListener, Mul
     @Override
     public void onItemClickedForDelete(final ArrayList<EmailMessage> emailsMarkedForAction) {
 
-        if (emailsMarkedForAction.size() == 0)
+        if (emailsMarkedForAction.isEmpty())
             setupDeleteAndComposeFABs(false);
         else
             setupDeleteAndComposeFABs(true);

--- a/app/src/main/java/com/sigmobile/dawebmail/services/BackgroundService.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/services/BackgroundService.java
@@ -59,7 +59,7 @@ public class BackgroundService extends Service implements RefreshInboxListener {
 
     @Override
     public void onPostRefresh(boolean success, ArrayList<EmailMessage> refreshedEmails, User user) {
-        if (refreshedEmails.size() == 0) {
+        if (refreshedEmails.isEmpty()) {
         } else if (refreshedEmails.size() == 1) {
             NotificationMaker.showNotification(this, user, refreshedEmails.get(0).getFromName(), refreshedEmails.get(0).getSubject());
             CurrentUser.setCurrentUser(user, getApplicationContext());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat
