### PR TITLE
Cleanup - squid:S1943 - Classes and methods that rely on the default …

### DIFF
--- a/app/src/main/java/com/sigmobile/dawebmail/network/MailParser.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/network/MailParser.java
@@ -7,6 +7,7 @@ import com.sigmobile.dawebmail.utils.BasePath;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import javax.mail.Multipart;
@@ -32,7 +33,7 @@ public class MailParser {
     public void newMailParser(Context context, int contentID, String emailContentBytes) {
         try {
             Session s = Session.getDefaultInstance(new Properties());
-            InputStream is = new ByteArrayInputStream(emailContentBytes.getBytes());
+            InputStream is = new ByteArrayInputStream(emailContentBytes.getBytes(StandardCharsets.UTF_8));
             MimeMessage message = new MimeMessage(s, is);
 
 //            javax.mail.Address[] fromAddress = message.getFrom();

--- a/app/src/main/java/com/sigmobile/dawebmail/network/RestAPI.java
+++ b/app/src/main/java/com/sigmobile/dawebmail/network/RestAPI.java
@@ -14,13 +14,14 @@ import org.json.JSONObject;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
@@ -243,13 +244,13 @@ public class RestAPI {
             conn.setRequestMethod("GET");
 
             String userPassword = user.getUsername() + ":" + user.getPassword();
-            String encoding = Base64.encodeToString(userPassword.getBytes(), Base64.DEFAULT);
+            String encoding = Base64.encodeToString(userPassword.getBytes(StandardCharsets.UTF_8), Base64.DEFAULT);
             conn.setRequestProperty("Authorization", "Basic " + encoding);
             conn.connect();
 
             if (conn.getResponseCode() == 200) {
                 InputStream in = new BufferedInputStream(conn.getInputStream());
-                BufferedReader r = new BufferedReader(new InputStreamReader(in));
+                BufferedReader r = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
                 StringBuilder total = new StringBuilder();
                 String line;
                 while ((line = r.readLine()) != null) {
@@ -277,7 +278,8 @@ public class RestAPI {
 
     public static void writeStringAsFile(Context context, final String fileContents) {
         try {
-            FileWriter out = new FileWriter(new File(BasePath.getBasePath(context), "email.txt"));
+            FileOutputStream fileOutputStream = new FileOutputStream(BasePath.getBasePath(context) + "/email.txt");
+            OutputStreamWriter out = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8);
             out.write(fileContents);
             out.close();
         } catch (IOException e) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat
